### PR TITLE
Add server redirects to root dart-lang.github.io

### DIFF
--- a/server/google-cloud-platform/index.html
+++ b/server/google-cloud-platform/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://dart.dev</title>
+<meta http-equiv="refresh" content="0; https://dart.dev/server/google-cloud?utm_source=dart-lang_github_io&utm_medium=Redirect&utm_content=meta_refresh">
+<link rel="canonical" href="https://dart.dev/server/google-cloud">

--- a/server/index.html
+++ b/server/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://dart.dev</title>
+<meta http-equiv="refresh" content="0; https://dart.dev/server?utm_source=dart-lang_github_io&utm_medium=Redirect&utm_content=meta_refresh">
+<link rel="canonical" href="https://dart.dev/server">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-   <sitemap>
-      <loc>https://dart-lang.github.io/observatory/sitemap.xml</loc>
-   </sitemap>
-   <sitemap>
-      <loc>https://dart-lang.github.io/server/sitemap.xml</loc>
-   </sitemap>
-</sitemapindex>


### PR DESCRIPTION
Will allow us to delete https://github.com/dart-lang/server/
